### PR TITLE
Extend generated locality statistics with correspondence and mention counts

### DIFF
--- a/post-install-generate.xql
+++ b/post-install-generate.xql
@@ -103,28 +103,36 @@ declare function gen:generate-localities-statistics($target as xs:string) {
             )
 
             (: Collect places of dispatch from <correspAction type="sent">. :)
-            let $sentRefs := distinct-values(
+            let $correspSentRefs := distinct-values(
                 $letter/tei:TEI/tei:teiHeader//tei:correspDesc//tei:correspAction[@type = 'sent']/tei:placeName/@ref/string()
             )
 
             (: Collect places of receipt from <correspAction type="received">. :)
-            let $receivedRefs := distinct-values(
+            let $correspReceivedRefs := distinct-values(
                 $letter/tei:TEI/tei:teiHeader//tei:correspDesc//tei:correspAction[@type = 'received']/tei:placeName/@ref/string()
             )
 
             (: Collect places from whole document (to match case "mentioned-places" in index.xql) :)
-            let $mentionRefs := distinct-values(
+            let $correspAndMentionsRefs := distinct-values(
                 $letter/tei:TEI//tei:placeName/@ref/string()
+            )
+
+            (: Collect places mentioned outside correspondence actions. :)
+            let $mentionsRefs := distinct-values(
+                $letter/tei:TEI//tei:placeName[
+                    not(ancestor::tei:correspAction)
+                ]/@ref/string()
             )
             
             return
-                for $ref in distinct-values(($correspRefs, $sentRefs, $receivedRefs, $mentionRefs))
+                for $ref in distinct-values(($correspRefs, $correspSentRefs, $correspReceivedRefs, $correspAndMentionsRefs, $mentionsRefs))
                 return map {
                     "place": $ref,
                     "corresp": if ($ref = $correspRefs) then 1 else 0,
-                    "sent": if ($ref = $sentRefs) then 1 else 0,
-                    "received": if ($ref = $receivedRefs) then 1 else 0,
-                    "mention": if ($ref = $mentionRefs) then 1 else 0
+                    "correspSent": if ($ref = $correspSentRefs) then 1 else 0,
+                    "correspReceived": if ($ref = $correspReceivedRefs) then 1 else 0,
+                    "correspAndMentions": if ($ref = $correspAndMentionsRefs) then 1 else 0,
+                    "mentions": if ($ref = $mentionsRefs) then 1 else 0
                 }
 
         return
@@ -138,16 +146,18 @@ declare function gen:generate-localities-statistics($target as xs:string) {
                         then map:get($acc, $placeID)
                         else map {
                             "corresp": 0,
-                            "sent": 0,
-                            "received": 0,
+                            "correspSent": 0,
+                            "correspReceived": 0,
+                            "correspAndMentions": 0,
                             "mentions": 0
                         }
 
                     let $updated := map {
                         "corresp": $existing?corresp + $entry?corresp,
-                        "sent": $existing?sent + $entry?sent,
-                        "received": $existing?received + $entry?received,
-                        "mentions": $existing?mentions + $entry?mention
+                        "correspSent": $existing?correspSent + $entry?correspSent,
+                        "correspReceived": $existing?correspReceived + $entry?correspReceived,
+                        "correspAndMentions": $existing?correspAndMentions + $entry?correspAndMentions,
+                        "mentions": $existing?mentions + $entry?mentions
                     }
 
                     return map:put($acc, $placeID, $updated)
@@ -161,8 +171,9 @@ declare function gen:generate-localities-statistics($target as xs:string) {
         return
             <item xml:id="{$placeID}">
                 <measure type="corresp">{$entry?corresp}</measure>
-                <measure type="sent">{$entry?sent}</measure>
-                <measure type="received">{$entry?received}</measure>
+                <measure type="correspSent">{$entry?correspSent}</measure>
+                <measure type="correspReceived">{$entry?correspReceived}</measure>
+                <measure type="correspAndMentions">{$entry?correspAndMentions}</measure>
                 <measure type="mentions">{$entry?mentions}</measure>
             </item>
 

--- a/post-install-generate.xql
+++ b/post-install-generate.xql
@@ -96,11 +96,20 @@ declare function gen:generate-localities-statistics($target as xs:string) {
     let $placeMap :=
         let $allRefs :=
             for $letter in $letters
-            let $id := $letter/tei:TEI/@xml:id/string()
 
             (: Collect places from <correspAction> only (to match case "place" in index.xql) :)
             let $correspRefs := distinct-values(
                 $letter/tei:TEI/tei:teiHeader//tei:correspDesc//tei:correspAction/tei:placeName/@ref/string()
+            )
+
+            (: Collect places of dispatch from <correspAction type="sent">. :)
+            let $sentRefs := distinct-values(
+                $letter/tei:TEI/tei:teiHeader//tei:correspDesc//tei:correspAction[@type = 'sent']/tei:placeName/@ref/string()
+            )
+
+            (: Collect places of receipt from <correspAction type="received">. :)
+            let $receivedRefs := distinct-values(
+                $letter/tei:TEI/tei:teiHeader//tei:correspDesc//tei:correspAction[@type = 'received']/tei:placeName/@ref/string()
             )
 
             (: Collect places from whole document (to match case "mentioned-places" in index.xql) :)
@@ -109,10 +118,12 @@ declare function gen:generate-localities-statistics($target as xs:string) {
             )
             
             return
-                for $ref in distinct-values(($correspRefs, $mentionRefs))
+                for $ref in distinct-values(($correspRefs, $sentRefs, $receivedRefs, $mentionRefs))
                 return map {
                     "place": $ref,
                     "corresp": if ($ref = $correspRefs) then 1 else 0,
+                    "sent": if ($ref = $sentRefs) then 1 else 0,
+                    "received": if ($ref = $receivedRefs) then 1 else 0,
                     "mention": if ($ref = $mentionRefs) then 1 else 0
                 }
 
@@ -125,10 +136,17 @@ declare function gen:generate-localities-statistics($target as xs:string) {
                     let $existing :=
                         if (map:contains($acc, $placeID))
                         then map:get($acc, $placeID)
-                        else map { "corresp": 0, "mentions": 0 }
+                        else map {
+                            "corresp": 0,
+                            "sent": 0,
+                            "received": 0,
+                            "mentions": 0
+                        }
 
                     let $updated := map {
                         "corresp": $existing?corresp + $entry?corresp,
+                        "sent": $existing?sent + $entry?sent,
+                        "received": $existing?received + $entry?received,
                         "mentions": $existing?mentions + $entry?mention
                     }
 
@@ -143,6 +161,8 @@ declare function gen:generate-localities-statistics($target as xs:string) {
         return
             <item xml:id="{$placeID}">
                 <measure type="corresp">{$entry?corresp}</measure>
+                <measure type="sent">{$entry?sent}</measure>
+                <measure type="received">{$entry?received}</measure>
                 <measure type="mentions">{$entry?mentions}</measure>
             </item>
 


### PR DESCRIPTION
This PR extends the generated locality register data (localities-statistics.xml) with detailed statistics about localities.

For each locality, the generated XML now includes the number of letters in which the locality appears as:
- a correspondence locality (corresp)
- a place of dispatch (correspSent)
- a place of receipt (correspReceived)
- either in correspondence metadata or elsewhere in the letter (correspAndMentions)
- mentioned outside correspondence metadata (mentions)

Each locality is counted at most once per letter and category.

These statistics are used by the Bullinger App to support locality-based filtering of correspondence and mentions.
(PR: https://github.com/stazh/bullinger-app/pull/10)
